### PR TITLE
fix icon missing issue

### DIFF
--- a/semantic-ui.html
+++ b/semantic-ui.html
@@ -1,21 +1,26 @@
 <!DOCTYPE html>
 <html>
+
+<head>
+
 <meta charset="utf-8" />
 
-
-<body>
-    
+<!--
 <script src="/js/semantic.min.js"></script>
+-->
 
+<!--
 <style type="text/css"> 
     @import url(http://ocf.tw/css/semantic.min.css); 
 </style>
-    
+-->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.12.3/semantic.min.css"/>
+
+</head>
+
+<body>    
     
 <div class="wrapper">
-    
-
-    
     <div class="shell">
         <div class="main">
             


### PR DESCRIPTION
讓 semanitc.min.css 也使用 cdn，避免 css 內外連路徑跑掉的問題，同時調整 html 結構，加入 head 標籤。
